### PR TITLE
Remove unused imports detected by CodeQL

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,6 +1,4 @@
-import json
 import re
-from dataclasses import dataclass, field
 from io import TextIOWrapper
 from typing import Tuple
 


### PR DESCRIPTION
These imports were from a previous incarnation and were no longer used. These were detected by the recently-installed CodeQL.