### PR TITLE
Test: downgrade actions/checkout to 3.5.1 to test dependabot

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@48e4ac706204bab735867521ba54b3276c883d00 # v3.1.3


### PR DESCRIPTION
Downgrading actions/checkout to 3.5.1 so we can test dependabot or some other dependency update tool.

I found the hash for 3.5.1 from the actions/checkout releases page: https://github.com/actions/checkout/releases/tag/v3.5.1.