### PR TITLE
Set workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,13 +20,16 @@ on:
   schedule:
     - cron: '31 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    
     permissions:
       actions: read
-      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add top-level read-only permissions to workflows. CodeQL requires `security-events: write`, but leave it at the job level so that future jobs added to the workflow can't accidentally get that permission.